### PR TITLE
Fix access on uninitialized data

### DIFF
--- a/header/HODLR_Node.hpp
+++ b/header/HODLR_Node.hpp
@@ -65,6 +65,7 @@ public:
 		this->parent                    =	NULL;
 		this->child[0]                  =	NULL;
 		this->child[1]                  =	NULL;
+		this->determinant               =	0;
 	};
 
         /*!

--- a/header_complex/HODLR_Node.hpp
+++ b/header_complex/HODLR_Node.hpp
@@ -66,6 +66,7 @@ public:
 		this->parent                    =	NULL;
 		this->child[0]                  =	NULL;
 		this->child[1]                  =	NULL;
+		this->determinant               =	0;
 	};
 
         /*!


### PR DESCRIPTION
This change initializes the variable determinant to 0. This prevents access on
a uninitialised variable.

Though I am not 100% sure, I think that the variable determinant is read but
never set when the value of log det A for a matrix A yields (numerically) 0.
From my tests this change fixes the access on uninitialized data (checked with
valgrind) and still yields correct results.