### PR TITLE
Improve README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,49 +18,49 @@ If you use the implementation or any part of the implementation in your work, ki
 
 ***Article***
 
-@article{ambikasaran2013fast,
+	@article{ambikasaran2013fast,
 
-  author={{A}mbikasaran, {S}ivaram and {D}arve, {E}ric},
-  
-  title={An $\mathcal{O}(N \log N)$ Fast Direct Solver for Partial Hierarchically Semi-Separable Matrices},
-  
-  journal={Journal of Scientific Computing},
-  
-  year={2013},
-  
-  volume={57},
-  
-  number={3},
-  
-  pages={477--501},
-  
-  month={December},
-  
-  publisher={Springer}
-  
-}
+	  author={{A}mbikasaran, {S}ivaram and {D}arve, {E}ric},
+
+	  title={An $\mathcal{O}(N \log N)$ Fast Direct Solver for Partial Hierarchically Semi-Separable Matrices},
+
+	  journal={Journal of Scientific Computing},
+
+	  year={2013},
+
+	  volume={57},
+
+	  number={3},
+
+	  pages={477--501},
+
+	  month={December},
+
+	  publisher={Springer}
+
+	}
 
 ***Code***
 
-@MISC{ambikasaran2013HODLR,
+	@MISC{ambikasaran2013HODLR,
 
-  author = {{A}mbikasaran, {S}ivaram},
-  
-  title = {A fast direct solver for dense linear systems},
-  
-  howpublished = {https://github.com/sivaramambikasaran/HODLR},
-  
-  year = {2013}
-  
- }
+	  author = {{A}mbikasaran, {S}ivaram},
+
+	  title = {A fast direct solver for dense linear systems},
+
+	  howpublished = {https://github.com/sivaramambikasaran/HODLR},
+
+	  year = {2013}
+
+	 }
 
 **Version 3.14**
 
-Date: November 14th, 2013
+	Date: November 14th, 2013
 
-Copyleft 2013: Sivaram Ambikasaran
+	Copyleft 2013: Sivaram Ambikasaran
 
-Developed by Sivaram Ambikasaran
+	Developed by Sivaram Ambikasaran
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,81 +1,100 @@
 # HODLR: Fast direct solver and determinant computation for dense linear systems
 
-This is an extension of the fast direct solver discussed in the article: "An O(N log (N)) Fast Direct Solver for Partial Hierarchically Semi-Separable Matrices". The solver has also been extended to matrices not necessarily arising out of kernels and also to higher dimensions. Further, the solver has been optimized and the running time of the solver is now massively (a few orders of magnitude) faster than the running times reported in the article. Low-rank approximation of the appropriate blocks are obtained using partial pivoted LU algorithm. The domain is sub-divided based on a KDTree. The solver is fairly general and works with minimal restrictions.
+This is an extension of the fast direct solver discussed in the article: "An
+O(N log (N)) Fast Direct Solver for Partial Hierarchically Semi-Separable
+Matrices". The solver has also been extended to matrices not necessarily
+arising out of kernels and also to higher dimensions. Further, the solver has
+been optimized and the running time of the solver is now massively (a few
+orders of magnitude) faster than the running times reported in the article.
+Low-rank approximation of the appropriate blocks are obtained using partial
+pivoted LU algorithm. The domain is sub-divided based on a KDTree. The solver
+is fairly general and works with minimal restrictions.
 
-To give a rough idea of the running time, for a system size of 1 million the solver takes 23 seconds for a 1D problem and 86 seconds for a 2D problem (this is time taken from the time you press the return key on the keyboard to run your code and to get the final result). The matrix is of the form
+To give a rough idea of the running time, for a system size of 1 million the
+solver takes 23 seconds for a 1D problem and 86 seconds for a 2D problem (this
+is time taken from the time you press the return key on the keyboard to run
+your code and to get the final result). The matrix is of the form
 
-		A	=	s^2 I + B
+    	A	=	s^2 I + B
 
-where B(i,j) depends on R(i,j), the distance between the points x(i) and x(j). The computed answer is accurate upto more than 10 digits. It is to be noted that even for higher dimensions (2D and 3D), the solver is still way faster than the conventional direct solvers, though the scaling may no longer be almost linear. The scaling depends on the smoothness of the kernel near the diagonal of the matrix.
+where B(i,j) depends on R(i,j), the distance between the points x(i) and x(j).
+The computed answer is accurate upto more than 10 digits. It is to be noted
+that even for higher dimensions (2D and 3D), the solver is still way faster
+than the conventional direct solvers, though the scaling may no longer be
+almost linear. The scaling depends on the smoothness of the kernel near the
+diagonal of the matrix.
 
 **Author**
 
-Sivaram Ambikasaran <siva.1985@gmail.com>
+Sivaram Ambikasaran <mailto:siva.1985@gmail.com>
 
 **Version 3.14**
 
-	Date: November 14th, 2013
+    Date: November 14th, 2013
 
-	Copyleft 2013: Sivaram Ambikasaran
+    Copyleft 2013: Sivaram Ambikasaran
 
-	Developed by Sivaram Ambikasaran
+    Developed by Sivaram Ambikasaran
 
 ## Citation
 
-If you use the implementation or any part of the implementation in your work, kindly cite as follows:
+If you use the implementation or any part of the implementation in your work,
+kindly cite as follows:
 
 **Article**
 
-	@article{ambikasaran2013fast,
+    @article{ambikasaran2013fast,
 
-	  author={{A}mbikasaran, {S}ivaram and {D}arve, {E}ric},
+      author={{A}mbikasaran, {S}ivaram and {D}arve, {E}ric},
 
-	  title={An $\mathcal{O}(N \log N)$ Fast Direct Solver for Partial Hierarchically Semi-Separable Matrices},
+      title={An $\mathcal{O}(N \log N)$ Fast Direct Solver for Partial Hierarchically Semi-Separable Matrices},
 
-	  journal={Journal of Scientific Computing},
+      journal={Journal of Scientific Computing},
 
-	  year={2013},
+      year={2013},
 
-	  volume={57},
+      volume={57},
 
-	  number={3},
+      number={3},
 
-	  pages={477--501},
+      pages={477--501},
 
-	  month={December},
+      month={December},
 
-	  publisher={Springer}
+      publisher={Springer}
 
-	}
+    }
 
 **Code**
 
-	@MISC{ambikasaran2013HODLR,
+    @MISC{ambikasaran2013HODLR,
 
-	  author = {{A}mbikasaran, {S}ivaram},
+      author = {{A}mbikasaran, {S}ivaram},
 
-	  title = {A fast direct solver for dense linear systems},
+      title = {A fast direct solver for dense linear systems},
 
-	  howpublished = {https://github.com/sivaramambikasaran/HODLR},
+      howpublished = {https://github.com/sivaramambikasaran/HODLR},
 
-	  year = {2013}
+      year = {2013}
 
-	 }
+     }
 
 ## License
 
-This program is free software; you can redistribute it and/or modify it under the terms of MPL2 license. The Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at <http://mozilla.org/MPL/2.0/.>
+This program is free software; you can redistribute it and/or modify it under
+the terms of MPL2 license. The Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with
+this file, You can obtain one at <http://mozilla.org/MPL/2.0/.>
 
 ## Directories and files
 
-
-	./examples/		:	Example input C++ codes; Needed to read input from user or from input file.
-	./src/			:	Source code in C++
-	./header/		:	Relevant header files
-	./exec/			:	Executables for HODLR
-	./README.md		:	This file
-	./LICENSE.md	:	License file
-	./makefile.mk	:	Makefile
+    ./examples/		:	Example input C++ codes; Needed to read input from user or from input file.
+    ./src/			:	Source code in C++
+    ./header/		:	Relevant header files
+    ./exec/			:	Executables for HODLR
+    ./README.md		:	This file
+    ./LICENSE.md	:	License file
+    ./makefile.mk	:	Makefile
 
 ## Usage
 
@@ -87,47 +106,52 @@ download and install Eigen following the instructions
 
 ### Build using cmake:
 
-The easiest way to build this library is using [CMake](http://cmake.org/).
-In the project directory, run:
-```
-mkdir build
-cd build
-cmake ..
-make
-make test
-[sudo] make install # optional
-```
-this will build the static `hodlr` library and run a few tests. If your
-version of the Eigen headers is installed in a non-standard place, you can
-change the `cmake` line to:
-```
-cmake .. -DEIGEN_INCLUDE_DIR_HINTS=/path/to/eigen
-```
+The easiest way to build this library is using [CMake](http://cmake.org/). In
+the project directory, run:
+
+    mkdir build
+    cd build
+    cmake ..
+    make
+    make test
+    [sudo] make install # optional
+
+this will build the static `hodlr` library and run a few tests. If your version
+of the Eigen headers is installed in a non-standard place, you can change the
+`cmake` line to:
+
+    cmake .. -DEIGEN_INCLUDE_DIR_HINTS=/path/to/eigen
 
 Your code should include `get_Matrix.hpp` and implement the function
-```
-double get_Matrix_Entry (const unsigned i, const unsigned j)
-```
 
+    double get_Matrix_Entry (const unsigned i, const unsigned j)
 
 ### Custom makefile:
 
-1. There is a sample input file named "HODLR_Test.cpp" in the directory './examples/'. This calls the features the code can handle.
+1.  There is a sample input file named "HODLR_Test.cpp" in the directory
+    './examples/'. This calls the features the code can handle.
 
-2. Go to the directory where makefile is in, then key in the following command in the terminal:
+2.  Go to the directory where makefile is in, then key in the following command
+    in the terminal:
 
-		make -f makefile.mk
+        make -f makefile.mk
 
-3. Once your run the make command, the executables are created in the directory named './exec/'. To run the code, go into the 'exec' directory and call './HODLR_Test'.
+3.  Once your run the make command, the executables are created in the
+    directory named './exec/'. To run the code, go into the 'exec' directory
+    and call './HODLR_Test'.
 
-4. You can change the kernels in the makefile by changing KERNEL. More kernels can be added by editing the function
+4.  You can change the kernels in the makefile by changing KERNEL. More kernels
+    can be added by editing the function
 
-		double get_Matrix_Entry(const unsigned i, const unsigned j)
+        double get_Matrix_Entry(const unsigned i, const unsigned j)
 
  in the file
 
-		get_Matrix.cpp
+        get_Matrix.cpp
 
-5. The dimension of the problem can be changed by changing DIM in the makefile.
+5.  The dimension of the problem can be changed by changing DIM in the makefile.
 
-6. Read through the comments in all the files. Most of the function/class/method/variable names are self-explanatory. Read the file HODLR_Test.cpp to understand how to assemble, factor, solver a new HODLR system.
+6.  Read through the comments in all the files. Most of the
+    function/class/method/variable names are self-explanatory. Read the file
+    HODLR_Test.cpp to understand how to assemble, factor, solver a new HODLR
+    system.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#HODLR: Fast direct solver and determinant computation for dense linear systems
+# HODLR: Fast direct solver and determinant computation for dense linear systems
 
 This is an extension of the fast direct solver discussed in the article: "An O(N log (N)) Fast Direct Solver for Partial Hierarchically Semi-Separable Matrices". The solver has also been extended to matrices not necessarily arising out of kernels and also to higher dimensions. Further, the solver has been optimized and the running time of the solver is now massively (a few orders of magnitude) faster than the running times reported in the article. Low-rank approximation of the appropriate blocks are obtained using partial pivoted LU algorithm. The domain is sub-divided based on a KDTree. The solver is fairly general and works with minimal restrictions.
 
@@ -66,7 +66,7 @@ Developed by Sivaram Ambikasaran
 
 This program is free software; you can redistribute it and/or modify it under the terms of MPL2 license. The Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at <http://mozilla.org/MPL/2.0/.>
 
-###DIRECTORIES AND FILES
+### DIRECTORIES AND FILES
 
 
 	./examples/		:	Example input C++ codes; Needed to read input from user or from input file.
@@ -77,15 +77,15 @@ This program is free software; you can redistribute it and/or modify it under th
 	./LICENSE.md	:	License file
 	./makefile.mk	:	Makefile
 
-##Usage
+## Usage
 
-###DEPENDENCIES:
+### DEPENDENCIES:
 
 To run this package, you need to have **Eigen**. If you don't already have it,
 download and install Eigen following the instructions
 [here](http://eigen.tuxfamily.org/index.php?title=Main_Page).
 
-###BUILD USING CMAKE:
+### BUILD USING CMAKE:
 
 The easiest way to build this library is using [CMake](http://cmake.org/).
 In the project directory, run:
@@ -110,7 +110,7 @@ double get_Matrix_Entry (const unsigned i, const unsigned j)
 ```
 
 
-###CUSTOM MAKEFILE:
+### CUSTOM MAKEFILE:
 
 1. There is a sample input file named "HODLR_Test.cpp" in the directory './examples/'. This calls the features the code can handle.
 

--- a/README.md
+++ b/README.md
@@ -109,22 +109,28 @@ download and install Eigen following the instructions
 The easiest way to build this library is using [CMake](http://cmake.org/). In
 the project directory, run:
 
-    mkdir build
-    cd build
-    cmake ..
-    make
-    make test
-    [sudo] make install # optional
+```bash
+mkdir build
+cd build
+cmake ..
+make
+make test
+[sudo] make install # optional
+```
 
 this will build the static `hodlr` library and run a few tests. If your version
 of the Eigen headers is installed in a non-standard place, you can change the
 `cmake` line to:
 
-    cmake .. -DEIGEN_INCLUDE_DIR_HINTS=/path/to/eigen
+```bash
+cmake .. -DEIGEN_INCLUDE_DIR_HINTS=/path/to/eigen
+```
 
 Your code should include `get_Matrix.hpp` and implement the function
 
-    double get_Matrix_Entry (const unsigned i, const unsigned j)
+```c++
+double get_Matrix_Entry (const unsigned i, const unsigned j)
+```
 
 ### Custom makefile:
 

--- a/README.md
+++ b/README.md
@@ -134,30 +134,28 @@ double get_Matrix_Entry (const unsigned i, const unsigned j)
 
 ### Custom makefile:
 
-1.  There is a sample input file named "HODLR_Test.cpp" in the directory
-    './examples/'. This calls the features the code can handle.
+1.  There is a sample input file named `HODLR_Test.cpp` in the directory
+    `./examples/`. This calls the features the code can handle.
 
 2.  Go to the directory where makefile is in, then key in the following command
-    in the terminal:
-
-        make -f makefile.mk
+    in the terminal: `make -f makefile.mk`.
 
 3.  Once your run the make command, the executables are created in the
-    directory named './exec/'. To run the code, go into the 'exec' directory
-    and call './HODLR_Test'.
+    directory named `./exec/`. To run the code, go into the `exec` directory
+    and call `./HODLR_Test`.
 
 4.  You can change the kernels in the makefile by changing KERNEL. More kernels
-    can be added by editing the function
+    can be added by editing the following function in the file
+	`get_Matrix.cpp`:
 
-        double get_Matrix_Entry(const unsigned i, const unsigned j)
+	```c++
+	double get_Matrix_Entry(constunsigned i, const unsigned j)
+	```
 
- in the file
-
-        get_Matrix.cpp
-
-5.  The dimension of the problem can be changed by changing DIM in the makefile.
+5.  The dimension of the problem can be changed by changing DIM in the
+    makefile.
 
 6.  Read through the comments in all the files. Most of the
     function/class/method/variable names are self-explanatory. Read the file
-    HODLR_Test.cpp to understand how to assemble, factor, solver a new HODLR
+    `HODLR_Test.cpp` to understand how to assemble, factor, solver a new HODLR
     system.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ solver takes 23 seconds for a 1D problem and 86 seconds for a 2D problem (this
 is time taken from the time you press the return key on the keyboard to run
 your code and to get the final result). The matrix is of the form
 
-    	A	=	s^2 I + B
+        A    =    s^2 I + B
 
 where B(i,j) depends on R(i,j), the distance between the points x(i) and x(j).
 The computed answer is accurate upto more than 10 digits. It is to be noted
@@ -88,13 +88,13 @@ this file, You can obtain one at <http://mozilla.org/MPL/2.0/.>
 
 ## Directories and files
 
-    ./examples/		:	Example input C++ codes; Needed to read input from user or from input file.
-    ./src/			:	Source code in C++
-    ./header/		:	Relevant header files
-    ./exec/			:	Executables for HODLR
-    ./README.md		:	This file
-    ./LICENSE.md	:	License file
-    ./makefile.mk	:	Makefile
+    ./examples/     :    Example input C++ codes; Needed to read input from user or from input file.
+    ./src/          :    Source code in C++
+    ./header/       :    Relevant header files
+    ./exec/         :    Executables for HODLR
+    ./README.md     :    This file
+    ./LICENSE.md    :    License file
+    ./makefile.mk   :    Makefile
 
 ## Usage
 
@@ -146,11 +146,11 @@ double get_Matrix_Entry (const unsigned i, const unsigned j)
 
 4.  You can change the kernels in the makefile by changing KERNEL. More kernels
     can be added by editing the following function in the file
-	`get_Matrix.cpp`:
+    `get_Matrix.cpp`:
 
-	```c++
-	double get_Matrix_Entry(constunsigned i, const unsigned j)
-	```
+    ```c++
+    double get_Matrix_Entry(constunsigned i, const unsigned j)
+    ```
 
 5.  The dimension of the problem can be changed by changing DIM in the
     makefile.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,19 @@ where B(i,j) depends on R(i,j), the distance between the points x(i) and x(j). T
 
 Sivaram Ambikasaran <siva.1985@gmail.com>
 
+**Version 3.14**
+
+	Date: November 14th, 2013
+
+	Copyleft 2013: Sivaram Ambikasaran
+
+	Developed by Sivaram Ambikasaran
+
 ## Citation
 
 If you use the implementation or any part of the implementation in your work, kindly cite as follows:
 
-***Article***
+**Article**
 
 	@article{ambikasaran2013fast,
 
@@ -40,7 +48,7 @@ If you use the implementation or any part of the implementation in your work, ki
 
 	}
 
-***Code***
+**Code**
 
 	@MISC{ambikasaran2013HODLR,
 
@@ -53,14 +61,6 @@ If you use the implementation or any part of the implementation in your work, ki
 	  year = {2013}
 
 	 }
-
-**Version 3.14**
-
-	Date: November 14th, 2013
-
-	Copyleft 2013: Sivaram Ambikasaran
-
-	Developed by Sivaram Ambikasaran
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ where B(i,j) depends on R(i,j), the distance between the points x(i) and x(j). T
 
 Sivaram Ambikasaran <siva.1985@gmail.com>
 
-**Citation**
+## Citation
 
 If you use the implementation or any part of the implementation in your work, kindly cite as follows:
 
@@ -62,11 +62,11 @@ Copyleft 2013: Sivaram Ambikasaran
 
 Developed by Sivaram Ambikasaran
 
-**License**
+## License
 
 This program is free software; you can redistribute it and/or modify it under the terms of MPL2 license. The Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at <http://mozilla.org/MPL/2.0/.>
 
-### DIRECTORIES AND FILES
+## Directories and files
 
 
 	./examples/		:	Example input C++ codes; Needed to read input from user or from input file.
@@ -79,13 +79,13 @@ This program is free software; you can redistribute it and/or modify it under th
 
 ## Usage
 
-### DEPENDENCIES:
+### Dependencies:
 
 To run this package, you need to have **Eigen**. If you don't already have it,
 download and install Eigen following the instructions
 [here](http://eigen.tuxfamily.org/index.php?title=Main_Page).
 
-### BUILD USING CMAKE:
+### Build using cmake:
 
 The easiest way to build this library is using [CMake](http://cmake.org/).
 In the project directory, run:
@@ -110,7 +110,7 @@ double get_Matrix_Entry (const unsigned i, const unsigned j)
 ```
 
 
-### CUSTOM MAKEFILE:
+### Custom makefile:
 
 1. There is a sample input file named "HODLR_Test.cpp" in the directory './examples/'. This calls the features the code can handle.
 


### PR DESCRIPTION
This pull request concerns 8 commits within `README.md`:

-   **Fix README headers**

    Github markdown headers require a space between the hash symbol and the
    text. If this space is not present the html is not generated properly.
    This commit adds the space.

-   **Improve header consistency**

    This commit will improve the consitency of header level. It will also
    remove the capitalization from the final set of headers, allowing the
    header level to dictate emphasis.

-   **Wrap citation information in a code block**

    The citation information should be presented in a code block. This will
    allow the indentation to remain present after the html is generated, and
    will show that the content is supposed to be copied to where required.

-   **Move version information out of citation section**

    The version information is now presented along with the authorship
    information. The headerfor citation are now bold, rather than bold and
    italics.

-   **Improve consistency of raw markdown**

    All paragraphs are now wrapped to 79 chars. The list within the section
    `Custom makefile` is wrapped with hanging indents. The linebreaks
    included are now more consistent.


-   **Use syntax highlighting when available**

    Syntax highlighting can make the text easier to understand. WHen the
    html is generated, the text will be colored appropriately.

-   **Improve consitency of inline code instructions**

    This commit modifies the instructions in the `Custom makefile` section.
    The quotation symbols (`'` and `"`) have been replaced with tildes
    ( ` ). This will clearly differentiate the code from the prose.

-   **Replace tabs with spaces**

    In markdown tabs can result in unpredictable behaviour. Spaces are thus
    more reliable.

Overall, this will make the REAMDE easier to navigate and make use of.