### PR TITLE
Avoid integer division in tutorial

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -28,7 +28,7 @@ The matrix that needs to be solved for is abstracted through this derived class 
 
             dtype getMatrixEntry(int i, int j) 
             {
-                return (1 / (i + j + 1));
+                return (1. / (i + j + 1));
             }
     }
 


### PR DESCRIPTION
The type of the numerator and the denumerator are both integer/unsigned
integer. Therefore, the division operator corresponds to integer division. This
commit makes the numerator a double to get the expected result.