### PR TITLE
Fixes few issues pointed out in review

### DIFF
--- a/examples/example_RPY.cpp
+++ b/examples/example_RPY.cpp
@@ -86,13 +86,35 @@ public:
 
 int main(int argc, char* argv[]) 
 {
-    // Size of the Matrix in consideration:
-    int N             = atoi(argv[1]);
-    // Size of Matrices at leaf level:
-    int M             = atoi(argv[2]);
-    // Tolerance of problem
-    int dim           = atoi(argv[3]);
-    double tolerance  = pow(10, -atoi(argv[4]));
+    int N, M, dim;
+    double tolerance;
+
+    if(argc < 5)
+    {
+        std::cout << "All arguments weren't passed to executable!" << std::endl;
+        std::cout << "Using Default Arguments:" << std::endl;
+        // Size of the Matrix in consideration:
+        N          = 10000;
+        // Size of Matrices at leaf level:
+        M          = 200;
+        // Dimensionality of the problem:
+        dim        = 1;
+        // Tolerance of problem
+        tolerance  = pow(10, -12);
+    }
+
+    else
+    {
+        // Size of the Matrix in consideration:
+        N          = atoi(argv[1]);
+        // Size of Matrices at leaf level:
+        M          = atoi(argv[2]);
+        // Dimensionality of the problem:
+        dim        = atoi(argv[3]);
+        // Tolerance of problem
+        tolerance  = pow(10, -atoi(argv[4]));
+    }
+
     // Declaration of HODLR_Matrix object that abstracts data in Matrix:
     // Setting k = T = η = 1
     Kernel* K         = new Kernel(N, dim, 1, 1, 1);

--- a/examples/example_matern.cpp
+++ b/examples/example_matern.cpp
@@ -35,12 +35,31 @@ public:
 
 int main(int argc, char* argv[]) 
 {
-    // Size of the Matrix in consideration:
-    int N             = atoi(argv[1]);
-    // Size of Matrices at leaf level:
-    int M             = atoi(argv[2]);
-    // Tolerance of problem
-    double tolerance  = pow(10, -atoi(argv[3]));
+    int N, M;
+    double tolerance;
+
+    if(argc < 4)
+    {
+        std::cout << "All arguments weren't passed to executable!" << std::endl;
+        std::cout << "Using Default Arguments:" << std::endl;
+        // Size of the Matrix in consideration:
+        N          = 10000;
+        // Size of Matrices at leaf level:
+        M          = 200;
+        // Tolerance of problem
+        tolerance  = pow(10, -12);
+    }
+
+    else
+    {
+        // Size of the Matrix in consideration:
+        N          = atoi(argv[1]);
+        // Size of Matrices at leaf level:
+        M          = atoi(argv[2]);
+        // Tolerance of problem
+        tolerance  = pow(10, -atoi(argv[3]));
+    }
+
     // Declaration of HODLR_Matrix object that abstracts data in Matrix:
     // Taking σ = 10, ρ = 5:
     Kernel* K         = new Kernel(N, 10, 5);

--- a/examples/tutorial.cpp
+++ b/examples/tutorial.cpp
@@ -81,31 +81,52 @@ public:
 
 int main(int argc, char* argv[]) 
 {
-    // Size of the Matrix in consideration:
-    int N             = atoi(argv[1]);
-    // Size of Matrices at leaf level:
-    int M             = atoi(argv[2]);
-    // Dimensionality of the problem:
-    int dim           = atoi(argv[3]);
-    // Tolerance of problem
-    double tolerance  = pow(10, -atoi(argv[4]));
-    // Declaration of HODLR_Matrix object that abstracts data in Matrix:
-    Kernel* K         = new Kernel(N, dim);
-    int n_levels      = log(N / M) / log(2);
+    int N, M, dim;
+    double tolerance;
 
-    cout << "========================= Problem Parameters =========================" << endl;
-    cout << "Matrix Size                        :" << N << endl;
-    cout << "Leaf Size                          :" << M << endl;
-    cout << "Number of Levels in Tree           :" << n_levels << endl;
-    cout << "Dimensionality                     :" << dim << endl;
-    cout << "Tolerance                          :" << tolerance << endl << endl;
+    if(argc < 5)
+    {
+        std::cout << "All arguments weren't passed to executable!" << std::endl;
+        std::cout << "Using Default Arguments:" << std::endl;
+        // Size of the Matrix in consideration:
+        N          = 10000;
+        // Size of Matrices at leaf level:
+        M          = 200;
+        // Dimensionality of the problem:
+        dim        = 1;
+        // Tolerance of problem
+        tolerance  = pow(10, -12);
+    }
+
+    else
+    {
+        // Size of the Matrix in consideration:
+        N          = atoi(argv[1]);
+        // Size of Matrices at leaf level:
+        M          = atoi(argv[2]);
+        // Dimensionality of the problem:
+        dim        = atoi(argv[3]);
+        // Tolerance of problem
+        tolerance  = pow(10, -atoi(argv[4]));
+    }
+
+    // Declaration of HODLR_Matrix object that abstracts data in Matrix:
+    Kernel* K    = new Kernel(N, dim);
+    int n_levels = log(N / M) / log(2);
+
+    std::cout << "========================= Problem Parameters =========================" << std::endl;
+    std::cout << "Matrix Size                        :" << N << std::endl;
+    std::cout << "Leaf Size                          :" << M << std::endl;
+    std::cout << "Number of Levels in Tree           :" << n_levels << std::endl;
+    std::cout << "Dimensionality                     :" << dim << std::endl;
+    std::cout << "Tolerance                          :" << tolerance << std::endl << std::endl;
 
     // Variables used in timing:
     double start, end;
 
     // Storing Time Taken:
     double hodlr_time, exact_time;
-    cout << "========================= Assembly Time =========================" << endl;
+    std::cout << "========================= Assembly Time =========================" << std::endl;
     start = omp_get_wtime();
     // Creating a pointer to the HODLR Tree structure:
     HODLR_Tree* T = new HODLR_Tree(n_levels, tolerance, K);
@@ -119,7 +140,7 @@ int main(int argc, char* argv[])
     T->assembleTree(is_sym, is_pd);
     end = omp_get_wtime();
     hodlr_time = (end - start);
-    cout << "Time for assembly in HODLR form    :" << hodlr_time << endl;
+    std::cout << "Time for assembly in HODLR form    :" << hodlr_time << std::endl;
 
     // What we are doing here is explicitly generating 
     // the matrix from its entries
@@ -127,8 +148,8 @@ int main(int argc, char* argv[])
     Mat B = K->getMatrix(0, 0, N, N);
     end   = omp_get_wtime();
     exact_time = (end - start);
-    cout << "Time for direct matrix generation  :" << exact_time << endl;
-    cout << "Magnitude of Speed-Up              :" << (exact_time / hodlr_time) << endl << endl;
+    std::cout << "Time for direct matrix generation  :" << exact_time << std::endl;
+    std::cout << "Magnitude of Speed-Up              :" << (exact_time / hodlr_time) << std::endl << std::endl;
 
     // These are mainly used in development and debugging:
     // Used to visualize the rank structure of the considered kernel:
@@ -141,28 +162,28 @@ int main(int argc, char* argv[])
     // Stores the result after multiplication:
     Mat y_fast, b_fast;
 
-    cout << "========================= Matrix-Vector Multiplication =========================" << endl;
+    std::cout << "========================= Matrix-Vector Multiplication =========================" << std::endl;
     start  = omp_get_wtime();
     b_fast = T->matmatProduct(x);
     end    = omp_get_wtime();
     hodlr_time = (end - start);
-    cout << "Time for MatVec in HODLR form      :" << hodlr_time << endl;
+    std::cout << "Time for MatVec in HODLR form      :" << hodlr_time << std::endl;
 
     start = omp_get_wtime();
     Mat b_exact = B * x;
     end   = omp_get_wtime();
     exact_time = (end - start);
-    cout << "Time for direct MatVec             :" << exact_time << endl;
-    cout << "Magnitude of Speed-Up              :" << (exact_time / hodlr_time) << endl;
+    std::cout << "Time for direct MatVec             :" << exact_time << std::endl;
+    std::cout << "Magnitude of Speed-Up              :" << (exact_time / hodlr_time) << std::endl;
     // Computing the relative error in the solution obtained:
-    cout << "Error in the solution is           :" << (b_fast-b_exact).norm() / (b_exact.norm()) << endl << endl;
+    std::cout << "Error in the solution is           :" << (b_fast-b_exact).norm() / (b_exact.norm()) << std::endl << std::endl;
 
-    cout << "========================= Factorization =========================" << endl;
+    std::cout << "========================= Factorization =========================" << std::endl;
     start = omp_get_wtime();
     T->factorize();
     end   = omp_get_wtime();
     hodlr_time = (end - start);
-    cout << "Time to factorize HODLR form       :" << hodlr_time << endl;
+    std::cout << "Time to factorize HODLR form       :" << hodlr_time << std::endl;
 
     Eigen::LLT<Mat> llt;
     Eigen::PartialPivLU<Mat> lu;
@@ -174,7 +195,7 @@ int main(int argc, char* argv[])
         llt.compute(B);
         end = omp_get_wtime();
         exact_time = (end - start);
-        cout << "Time for Cholesky Factorization    :" << exact_time << endl;
+        std::cout << "Time for Cholesky Factorization    :" << exact_time << std::endl;
     }
 
     // Factorizing using LU:
@@ -184,18 +205,18 @@ int main(int argc, char* argv[])
         lu.compute(B);
         end = omp_get_wtime();
         exact_time = (end - start);
-        cout << "Time for LU Factorization          :" << exact_time << endl;
+        std::cout << "Time for LU Factorization          :" << exact_time << std::endl;
     }
 
-    cout << "Magnitude of Speed-Up              :" << (exact_time / hodlr_time) << endl << endl;
+    std::cout << "Magnitude of Speed-Up              :" << (exact_time / hodlr_time) << std::endl << std::endl;
 
-    cout << "========================= Solving =========================" << endl;
+    std::cout << "========================= Solving =========================" << std::endl;
     Mat x_fast;
     start  = omp_get_wtime();
     x_fast = T->solve(b_exact);
     end    = omp_get_wtime();
     hodlr_time = (end - start);
-    cout << "Time to solve HODLR form           :" << hodlr_time << endl;
+    std::cout << "Time to solve HODLR form           :" << hodlr_time << std::endl;
 
     // This is intentionally declared to be different from x:
     Mat x_exact;
@@ -214,21 +235,21 @@ int main(int argc, char* argv[])
     }
 
     exact_time = (end - start);
-    cout << "Time taken to solve exactly        :" << exact_time << endl;
-    cout << "Magnitude of Speed-Up              :" << (exact_time / hodlr_time) << endl;
+    std::cout << "Time taken to solve exactly        :" << exact_time << std::endl;
+    std::cout << "Magnitude of Speed-Up              :" << (exact_time / hodlr_time) << std::endl;
     // Computing the relative error:
-    cout << "Forward Error(HODLR)               :" << (x_fast - x).norm() / (x.norm()) << endl;
-    cout << "Forward Error(Exact)               :" << (x_exact - x).norm() / (x.norm()) << endl;
-    cout << "Backward Error(HODLR)              :" << (T->matmatProduct(x_fast) - b_exact).norm() / b_exact.norm() << endl;
-    cout << "Backward Error(Exact)              :" << (B * x_exact - b_exact).norm() / b_exact.norm() << endl << endl;
+    std::cout << "Forward Error(HODLR)               :" << (x_fast - x).norm() / (x.norm()) << std::endl;
+    std::cout << "Forward Error(Exact)               :" << (x_exact - x).norm() / (x.norm()) << std::endl;
+    std::cout << "Backward Error(HODLR)              :" << (T->matmatProduct(x_fast) - b_exact).norm() / b_exact.norm() << std::endl;
+    std::cout << "Backward Error(Exact)              :" << (B * x_exact - b_exact).norm() / b_exact.norm() << std::endl << std::endl;
 
-    cout << "========================= Determinant Computation =========================" << endl;
+    std::cout << "========================= Determinant Computation =========================" << std::endl;
     // Gets the log(determinant) of the matrix abstracted through Kernel:
     start = omp_get_wtime();
     dtype log_det_hodlr = T->logDeterminant();
     end = omp_get_wtime();
-    cout << "Time taken for HODLR form          :" << (end-start) << endl;
-    cout << "Calculated Log Determinant(HODLR)  :" << log_det_hodlr << endl;
+    std::cout << "Time taken for HODLR form          :" << (end-start) << std::endl;
+    std::cout << "Calculated Log Determinant(HODLR)  :" << log_det_hodlr << std::endl;
 
     dtype log_det;
     // Computing log-determinant using Cholesky:
@@ -240,7 +261,7 @@ int main(int argc, char* argv[])
             log_det += log(fabs(llt.matrixL()(i,i)));
         }
         log_det *= 2;
-        cout << "Calculated Log Determinant(Exact)  :" << log_det << endl;
+        std::cout << "Calculated Log Determinant(Exact)  :" << log_det << std::endl;
     }
 
     // Computing log-determinant using LU:
@@ -251,29 +272,29 @@ int main(int argc, char* argv[])
         {
             log_det += log(fabs(lu.matrixLU()(i,i)));
         }
-        cout << "Calculated Log Determinant(Exact)  :" << log_det << endl;
+        std::cout << "Calculated Log Determinant(Exact)  :" << log_det << std::endl;
     }
 
-    cout << "Relative Error in computation      :" << fabs(1 - fabs(log_det_hodlr/log_det)) << endl << endl;
+    std::cout << "Relative Error in computation      :" << fabs(1 - fabs(log_det_hodlr/log_det)) << std::endl << std::endl;
 
     // These routines are specific to the fast symmetric factorization routine:
     // Checking symmetric factor product:
     if(is_sym == true && is_pd == true)
     {
-        cout << "========================= Multiplication With Symmetric Factor =========================" << endl;
+        std::cout << "========================= Multiplication With Symmetric Factor =========================" << std::endl;
         // We set y = W^T x
         start  = omp_get_wtime();
         y_fast = T->symmetricFactorTransposeProduct(x);
         end    = omp_get_wtime();
-        cout << "Time to calculate product of factor transpose with given vector:" << (end - start) << endl;
+        std::cout << "Time to calculate product of factor transpose with given vector:" << (end - start) << std::endl;
         
         // b = W y = W W^T x = B * x
         start  = omp_get_wtime();
         b_fast = T->symmetricFactorProduct(y_fast);
         end    = omp_get_wtime();
-        cout << "Time to calculate product of factor with given vector          :" << (end - start) << endl;
+        std::cout << "Time to calculate product of factor with given vector          :" << (end - start) << std::endl;
 
-        cout << "Error in the solution is                                       :" << (b_fast - b_exact).norm() / (b_exact.norm()) << endl << endl;
+        std::cout << "Error in the solution is                                       :" << (b_fast - b_exact).norm() / (b_exact.norm()) << std::endl << std::endl;
     }
 
     // If we want to explicitly build the symmetric factor matrix, then we can call this command

--- a/src/HODLR_Matrix.hpp
+++ b/src/HODLR_Matrix.hpp
@@ -14,9 +14,6 @@
 #include <fstream>
 #include <complex>
 
-using std::cout;
-using std::endl;
-
 #ifdef USE_FLOAT
     using dtype=float;
     using dtype_base=float;
@@ -70,7 +67,7 @@ public:
     {
         // FROM EXPERIENCE: Incase the user makes a mistake in 
         // setting the derived class, this warns the user:
-        cout << "Returning zero! Ensure that derived class is properly set!" << endl;
+        std::cout << "Returning zero! Ensure that derived class is properly set!" << std::endl;
         return 0.0;
     }
 

--- a/src/HODLR_Node.cpp
+++ b/src/HODLR_Node.cpp
@@ -58,26 +58,26 @@ void HODLR_Node::matmatProductNonLeaf(Mat x, Mat& b)
 
 void HODLR_Node::printNodeDetails()
 {
-    cout << "Level Number       :" << level_number << endl;
-    cout << "Node Number        :" << node_number << endl;
-    cout << "Start of Node      :" << n_start <<  endl;
-    cout << "Size of Node       :" << n_size <<  endl;
-    cout << "Tolerance          :" << tolerance << endl;
+    std::cout << "Level Number       :" << level_number << std::endl;
+    std::cout << "Node Number        :" << node_number << std::endl;
+    std::cout << "Start of Node      :" << n_start <<  std::endl;
+    std::cout << "Size of Node       :" << n_size <<  std::endl;
+    std::cout << "Tolerance          :" << tolerance << std::endl;
 
     for(int i = 0; i < 2; i++)
     {
         if(i == 0)
-            cout << "Left Child:" << endl;
+            std::cout << "Left Child:" << std::endl;
         else
-            cout << "Right Child:" << endl;
+            std::cout << "Right Child:" << std::endl;
 
-        cout << "Start of Child Node:" << c_start[i] <<  endl;
-        cout << "Size of Child Node :" << c_size[i]  <<  endl;
+        std::cout << "Start of Child Node:" << c_start[i] <<  std::endl;
+        std::cout << "Size of Child Node :" << c_size[i]  <<  std::endl;
     }
 
-    cout << "Shape of U[0]      :" << U[0].rows() << ", " << U[0].cols() << endl;
-    cout << "Shape of U[1]      :" << U[1].rows() << ", " << U[1].cols() << endl;
-    cout << "Shape of V[0]      :" << V[0].rows() << ", " << V[0].cols() << endl;
-    cout << "Shape of V[1]      :" << V[1].rows() << ", " << V[1].cols() << endl;
-    cout << "Shape of K         :" << K.rows() << ", " << K.cols() << endl;
+    std::cout << "Shape of U[0]      :" << U[0].rows() << ", " << U[0].cols() << std::endl;
+    std::cout << "Shape of U[1]      :" << U[1].rows() << ", " << U[1].cols() << std::endl;
+    std::cout << "Shape of V[0]      :" << V[0].rows() << ", " << V[0].cols() << std::endl;
+    std::cout << "Shape of V[1]      :" << V[1].rows() << ", " << V[1].cols() << std::endl;
+    std::cout << "Shape of K         :" << K.rows() << ", " << K.cols() << std::endl;
 }

--- a/src/HODLR_Tree.cpp
+++ b/src/HODLR_Tree.cpp
@@ -120,9 +120,9 @@ void HODLR_Tree::printTreeDetails()
         for(int k = 0; k < nodes_in_level[j]; k++)
         {
             this->printNodeDetails(j, k);
-            cout << "=======================================================================================================================================" << endl;
+            std::cout << "=======================================================================================================================================" << std::endl;
         }
-        cout << endl << endl;
+        std::cout << std::endl << std::endl;
     }
 }
 
@@ -186,22 +186,22 @@ dtype HODLR_Tree::logDeterminant()
 // Additionally, it also shows the ranks of the blocks. Again useful to debug:
 void HODLR_Tree::plotTree(std::string image_name)
 {
-    std::string HODLR_PATH = std::getenv("HODLR_PATH");
-    std::string FILE       = HODLR_PATH + "/src/plot_tree.py ";
-    std::string COMMAND    = "python " + FILE + image_name;
+    std::string hodlr_path = std::getenv("HODLR_PATH");
+    std::string file       = hodlr_path + "/src/plot_tree.py ";
+    std::string command    = "python " + file + image_name;
     std::ofstream myfile;
     myfile.open ("rank.txt");
     // First entry is the number of levels:
-    myfile << n_levels << endl;
+    myfile << n_levels << std::endl;
     for(int j = 0; j < n_levels; j++)
     {
         for(int k = 0; k < nodes_in_level[j]; k++)
         {
-            myfile << tree[j][k]->rank[0] << endl;
+            myfile << tree[j][k]->rank[0] << std::endl;
         }
     }
     // Closing the file:
     myfile.close();
-    cout << "Plotting Tree..." << endl;
-    system(COMMAND.c_str());
+    std::cout << "Plotting Tree..." << std::endl;
+    system(command.c_str());
 }

--- a/test/test_HODLR.cpp
+++ b/test/test_HODLR.cpp
@@ -198,6 +198,6 @@ int main(int argc, char* argv[])
     testHODLR(N, n_levels, tolerance, K3, "random_matrix_N_1943.svg");
     delete K3;
 
-    cout << "Reached End of Test File Successfully! All functions work as intended!" << endl;
+    std::cout << "Reached End of Test File Successfully! All functions work as intended!" << std::endl;
     return 0;
 }


### PR DESCRIPTION
- Now the example files use default argument values when the user doesn't provide them instead of segfaulting.
- Change of capital variable names in `plotTree`
- No longer is `using std::cout` and `using std::endl` used. However, `using` statements are still used for `Mat, Vec, dtype` and `dtype_base`