### PR TITLE
Correction to files under examples/

### DIFF
--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -61,7 +61,7 @@ public:
 int main(int argc, char *argv[])
 {
     unsigned int seed = time(NULL);
-    cout << "Seed is: " << seed << endl;
+    std::cout << "Seed is: " << seed << std::endl;
     srand(seed);
 
     // dimension
@@ -86,9 +86,9 @@ int main(int argc, char *argv[])
     // Compute log det(Id+M)
     logdet_hodlr = T->logDeterminant();
 
-    cout << "Log determinant is: " << setprecision(16) << logdet_hodlr << endl;
-    cout << "Log determinant is: " << setprecision(16) << logdet_exact << endl;
-    cout << "Relative error is: "  << setprecision(16) << fabs(1-logdet_hodlr/logdet_exact) << endl;
+    std::cout << "Log determinant is: " << setprecision(16) << logdet_hodlr << std::endl;
+    std::cout << "Log determinant is: " << setprecision(16) << logdet_exact << std::endl;
+    std::cout << "Relative error is: "  << setprecision(16) << fabs(1-logdet_hodlr/logdet_exact) << std::endl;
 
     return 0;
 }

--- a/examples/example_RPY.cpp
+++ b/examples/example_RPY.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
     // Variables used in timing:
     double start, end;
 
-    cout << "Fast method..." << endl;
+    std::cout << "Fast method..." << std::endl;
     start = omp_get_wtime();
     // Creating a pointer to the HODLR Tree structure:
     HODLR_Tree* T = new HODLR_Tree(n_levels, tolerance, K);
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
     bool is_pd  = true;
     T->assembleTree(is_sym, is_pd);
     end = omp_get_wtime();
-    cout << "Time for assembly in HODLR form:" << (end - start) << endl;
+    std::cout << "Time for assembly in HODLR form:" << (end - start) << std::endl;
 
     // Random Matrix to multiply with
     Mat x = (Mat::Random(N * dim, 1)).real();
@@ -142,37 +142,37 @@ int main(int argc, char* argv[])
     b_fast = T->matmatProduct(x);
     end    = omp_get_wtime();
     
-    cout << "Time for matrix-vector product:" << (end - start) << endl << endl;
+    std::cout << "Time for matrix-vector product:" << (end - start) << std::endl << std::endl;
 
     start = omp_get_wtime();
     T->factorize();
     end   = omp_get_wtime();
-    cout << "Time to factorize:" << (end-start) << endl;
+    std::cout << "Time to factorize:" << (end-start) << std::endl;
 
     Mat x_fast;
     start  = omp_get_wtime();
     x_fast = T->solve(b_fast);
     end    = omp_get_wtime();
 
-    cout << "Time to solve:" << (end-start) << endl;
+    std::cout << "Time to solve:" << (end-start) << std::endl;
 
     if(is_sym == true && is_pd == true)
     {
         start  = omp_get_wtime();
         y_fast = T->symmetricFactorTransposeProduct(x);
         end    = omp_get_wtime();
-        cout << "Time to calculate product of factor transpose with given vector:" << (end - start) << endl;
+        std::cout << "Time to calculate product of factor transpose with given vector:" << (end - start) << std::endl;
         
         start  = omp_get_wtime();
         b_fast = T->symmetricFactorProduct(y_fast);
         end    = omp_get_wtime();
-        cout << "Time to calculate product of factor with given vector:" << (end - start) << endl;        
+        std::cout << "Time to calculate product of factor with given vector:" << (end - start) << std::endl;        
     }
         
     start = omp_get_wtime();
     dtype log_det_hodlr = T->logDeterminant();
     end = omp_get_wtime();
-    cout << "Time to calculate log determinant using HODLR:" << (end-start) << endl;
+    std::cout << "Time to calculate log determinant using HODLR:" << (end-start) << std::endl;
 
     // Direct method:
     start = omp_get_wtime();
@@ -185,7 +185,7 @@ int main(int argc, char* argv[])
         Eigen::LLT<Mat> llt;
         llt.compute(B);
         end = omp_get_wtime();
-        cout << "Time to calculate LLT Factorization:" << (end-start) << endl;
+        std::cout << "Time to calculate LLT Factorization:" << (end-start) << std::endl;
     }
 
     else
@@ -194,7 +194,7 @@ int main(int argc, char* argv[])
         Eigen::PartialPivLU<Mat> lu;
         lu.compute(B);
         end = omp_get_wtime();
-        cout << "Time to calculate LU Factorization:" << (end-start) << endl;        
+        std::cout << "Time to calculate LU Factorization:" << (end-start) << std::endl;        
     }
 
     delete K;

--- a/examples/example_conducting_sphere_plate.cpp
+++ b/examples/example_conducting_sphere_plate.cpp
@@ -95,9 +95,9 @@ int main(int argc, char *argv[])
     // Compute determinant 
     logdet = T->logDeterminant();
 
-    cout << "Log determinant(Exact):" << setprecision(16) << exact << endl;
-    cout << "Log determinant(HODLR):" << setprecision(16) << logdet << endl;
-    cout << "Relative error is: "  << setprecision(16) << fabs(1 - logdet / exact) << endl;
+    std::cout << "Log determinant(Exact):" << setprecision(16) << exact << std::endl;
+    std::cout << "Log determinant(HODLR):" << setprecision(16) << logdet << std::endl;
+    std::cout << "Relative error is: "  << setprecision(16) << fabs(1 - logdet / exact) << std::endl;
 
     return 0;
 }

--- a/examples/example_matern.cpp
+++ b/examples/example_matern.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
     // Variables used in timing:
     double start, end;
 
-    cout << "Fast method..." << endl;
+    std::cout << "Fast method..." << std::endl;
     
     start = omp_get_wtime();
     // Creating a pointer to the HODLR Tree structure:
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
     bool is_pd  = true;
     T->assembleTree(is_sym, is_pd);
     end = omp_get_wtime();
-    cout << "Time for assembly in HODLR form:" << (end - start) << endl;
+    std::cout << "Time for assembly in HODLR form:" << (end - start) << std::endl;
 
     // Random Matrix to multiply with
     Mat x = (Mat::Random(N, 1)).real();
@@ -88,37 +88,37 @@ int main(int argc, char* argv[])
     b_fast = T->matmatProduct(x);
     end    = omp_get_wtime();
     
-    cout << "Time for matrix-vector product:" << (end - start) << endl << endl;
+    std::cout << "Time for matrix-vector product:" << (end - start) << std::endl << std::endl;
 
     start = omp_get_wtime();
     T->factorize();
     end   = omp_get_wtime();
-    cout << "Time to factorize:" << (end-start) << endl;
+    std::cout << "Time to factorize:" << (end-start) << std::endl;
 
     Mat x_fast;
     start  = omp_get_wtime();
     x_fast = T->solve(b_fast);
     end    = omp_get_wtime();
 
-    cout << "Time to solve:" << (end-start) << endl;
+    std::cout << "Time to solve:" << (end-start) << std::endl;
 
     if(is_sym == true && is_pd == true)
     {
         start  = omp_get_wtime();
         y_fast = T->symmetricFactorTransposeProduct(x);
         end    = omp_get_wtime();
-        cout << "Time to calculate product of factor transpose with given vector:" << (end - start) << endl;
+        std::cout << "Time to calculate product of factor transpose with given vector:" << (end - start) << std::endl;
         
         start  = omp_get_wtime();
         b_fast = T->symmetricFactorProduct(y_fast);
         end    = omp_get_wtime();
-        cout << "Time to calculate product of factor with given vector:" << (end - start) << endl;        
+        std::cout << "Time to calculate product of factor with given vector:" << (end - start) << std::endl;        
     }
         
     start = omp_get_wtime();
     dtype log_det_hodlr = T->logDeterminant();
     end = omp_get_wtime();
-    cout << "Time to calculate log determinant using HODLR:" << (end-start) << endl;
+    std::cout << "Time to calculate log determinant using HODLR:" << (end-start) << std::endl;
 
     // Direct method:
     start = omp_get_wtime();
@@ -131,7 +131,7 @@ int main(int argc, char* argv[])
         Eigen::LLT<Mat> llt;
         llt.compute(B);
         end = omp_get_wtime();
-        cout << "Time to calculate LLT Factorization:" << (end-start) << endl;
+        std::cout << "Time to calculate LLT Factorization:" << (end-start) << std::endl;
     }
 
     else
@@ -140,7 +140,7 @@ int main(int argc, char* argv[])
         Eigen::PartialPivLU<Mat> lu;
         lu.compute(B);
         end = omp_get_wtime();
-        cout << "Time to calculate LU Factorization:" << (end-start) << endl;        
+        std::cout << "Time to calculate LU Factorization:" << (end-start) << std::endl;        
     }
 
     delete K;


### PR DESCRIPTION
- Earlier, these examples were failing since they were using `cout`, and `endl`, rather than `std::cout`, and `std::endl`. This has now been corrected.