### PR TITLE
avoid warning when compiling with -Wsign-compare

### DIFF
--- a/src/HODLR_Matrix.cpp
+++ b/src/HODLR_Matrix.cpp
@@ -179,13 +179,13 @@ void HODLR_Matrix::rookPiv(int n_row_start, int n_col_start,
                     int max = 0;
                     int idx = 0;
 
-                    for(int i = 0; i < row_ind_sort.size() - 1; i++)
+                    for(unsigned int i = 1; i < row_ind_sort.size(); i++)
                     {
-                        row_ind_diff[i] = row_ind_sort[i+1] - row_ind_sort[i];
-                        if(row_ind_diff[i] > max)
+                        row_ind_diff[i-1] = row_ind_sort[i] - row_ind_sort[i-1];
+                        if(row_ind_diff[i-1] > max)
                         {
-                            idx = i;
-                            max = row_ind_diff[i];
+                            idx = i-1;
+                            max = row_ind_diff[i-1];
                         }
                     }
 
@@ -280,13 +280,13 @@ void HODLR_Matrix::rookPiv(int n_row_start, int n_col_start,
                     int max = 0;
                     int idx = 0;
 
-                    for(int i = 0; i < col_ind_sort.size() - 1; i++)
+                    for(unsigned int i = 1; i < col_ind_sort.size(); i++)
                     {
-                        col_ind_diff[i] = col_ind_sort[i+1] - col_ind_sort[i];
-                        if(col_ind_diff[i] > max)
+                        col_ind_diff[i-1] = col_ind_sort[i] - col_ind_sort[i-1];
+                        if(col_ind_diff[i-1] > max)
                         {
-                            idx = i;
-                            max = col_ind_diff[i];
+                            idx = i-1;
+                            max = col_ind_diff[i-1];
                         }
                     }
 


### PR DESCRIPTION
Currently, gcc issues a warning when compiling with -Wsign-compare (which is
activated when using -Wall):
```
$ src/HODLR_Matrix.cpp:287:38: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
           for(int i = 0; i < col_ind_sort.size() - 1; i++)
                          ~~^~~~~~~~~~~~~~~~~~~~~~~~~
```
This warning is issued for two very similar loops.

This commit avoids this problem by changing the type of the loop variable `i` to
`unsigned int`. In order to avoid wrap arounds when `col_ind_sort.size()` is 0 that
would break the logic, the index `i` has been shifted: `i->i+1`

Thus, the loop is executed exactly `row_ind_sort.size()-1` times if
`row_ind_sort.size()` is positive or zero times if `row_ind_sort.size()` is 0.
Consequently, every occurence of `i` in the loop body has been changed to `i-1`,
i.e. `i->i-1`.

I have tested the change and my unit tests still pass.