### PR TITLE
Avoid crashes when compiling with MSVC

### DIFF
--- a/src/LowRank.cpp
+++ b/src/LowRank.cpp
@@ -112,7 +112,7 @@ void LowRank::rookPiv(Mat& L, Mat& R, double tolerance_or_rank,
             {
                 if(eval_at_end == true)
                 {
-                    new_row_ind = *remaining_row_ind.end();
+                    new_row_ind = *--remaining_row_ind.end();
                 }
 
                 else


### PR DESCRIPTION
As far as I understand, `remaining_row_ind.end()` returns an iterator one past the end of the set. Dereferencing the iterator is thus undefined behaviour.

While the current code (surprisingly) worked on Linux with different versions of gcc, clang, and icc, the code crashes on Windows when I compile it with Visual Studio (MSVC).

Therefore, before dereferencing the iterator, the change decrements the iterator by one to get the last element of the set.

The change seems to fix the problem: The code still works on Linux and no longer crashes on Windows. I have tested the changes on Linux with my test suite computing more than 50 determinants.